### PR TITLE
Handle Android Webview

### DIFF
--- a/examples/base/paginate.js
+++ b/examples/base/paginate.js
@@ -5,10 +5,11 @@
   var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   var isIDevice = navigator.platform.substr(0,2) === 'iP';
   var isAndroid = /(android)/i.test(navigator.userAgent);
+  var isWebview = /(wv)/i.test(navigator.userAgent);
   var root = undefined;
   var page = 0;
 
-  if (isSafari) {
+  if (isSafari || isAndroid && isWebview) {
     var root = document.body;
   } else {
     var root = document.documentElement;


### PR DESCRIPTION
That’s more like a band-aid on a wooden leg but it should fix the tap issue in the Android Webview app. 

It looks like Chrome overflows columns on documentElement while the Webview overflows them on body… 

Can confirm the Webview app can be remote-debugged now. Thanks!

Can’t wait for the real JS to be used though.